### PR TITLE
Added a strict mode to fail if any warning

### DIFF
--- a/lib/bisu.rb
+++ b/lib/bisu.rb
@@ -33,6 +33,9 @@ module Bisu
     end
 
     Bisu::Logger.print_summary
+    if (options[:strict] && Bisu::Logger.summary[:warn] > 0)
+      Logger.error("Found a warning while in strict mode")
+    end
   end
 
   private
@@ -67,6 +70,10 @@ module Bisu
 
       opts.on("--save-dictionary PATH", "Save downloaded dictionary locally at given path") do |path|
         opts_hash[:dictionary_save_path] = path
+      end
+
+      opts.on("-s", "--strict", "Fail in the presence of any warning") do
+        opts_hash[:strict] = true
       end
 
       opts.on_tail("-h", "--help", "Show this message") do

--- a/lib/bisu.rb
+++ b/lib/bisu.rb
@@ -32,8 +32,8 @@ module Bisu
       end
     end
 
-    Bisu::Logger.print_summary
-    if (options[:strict] && Bisu::Logger.summary[:warn] > 0)
+    Logger.print_summary
+    if options[:strict] && Logger.summary[:warn] > 0
       Logger.error("Found a warning while in strict mode")
     end
   end

--- a/lib/bisu/version.rb
+++ b/lib/bisu/version.rb
@@ -1,4 +1,4 @@
 module Bisu
-  VERSION = '1.5.0'
-  VERSION_UPDATED_AT = '2018-01-21'
+  VERSION = '1.6.0'
+  VERSION_UPDATED_AT = '2018-10-17'
 end


### PR DESCRIPTION
### Problem
- Would be useful to run bisu during the CI's publish workflow to make sure we don't release with missing translations
- bisu doesn't fail in case a warning (missing translation) is found
- We still want this behavior to use during development (success with warnings)

### Solution
- Add a `--strict` flag which fails in case there is any warning, like a missing translation
- The CI should then run `bisu --strict`